### PR TITLE
Update copy to reflect new contact methods, association with Foursquare

### DIFF
--- a/app/assets/javascripts/items/ItemModal.js.coffee
+++ b/app/assets/javascripts/items/ItemModal.js.coffee
@@ -236,7 +236,7 @@ class ItemModal
           when textStatus == 'timeout' then "The request timed out. Please try again."
           else
             # Rollbar.error("AJAX Items Modal Error: ", {xhr: xhr, textStatus: textStatus, errorThrown: errorThrown})
-            "An unknown error occurred. Try again, and if the problem continues, please email 4sweep@4sweep.com"
+            "An unknown error occurred. Try again, and if the problem continues, please email foursweep@foursquare.com"
         @modal.find(".placeholder").html(HandlebarsTemplates['items/retry_placeholder']({errorText: errorText}))
 
       data: @requestParams()

--- a/app/assets/javascripts/search/FlagSubmissionService.js.coffee
+++ b/app/assets/javascripts/search/FlagSubmissionService.js.coffee
@@ -49,7 +49,7 @@ class FlagSubmissionService
       when textStatus == 'timeout' then "The request timed out. Please try again."
       else
         # Rollbar.error("AJAX error: ", {xhr: xhr, textStatus: textStatus, errorThrown: errorThrown})
-        "An unknown error occurred. Try again, and if the problem continues, please email 4sweep@4sweep.com"
+        "An unknown error occurred. Try again, and if the problem continues, please email foursweep@foursquare.com"
     $.pnotify
       title: "An error occurred"
       text: "\n" + errorText

--- a/app/assets/javascripts/search/Searches/Search.js.coffee
+++ b/app/assets/javascripts/search/Searches/Search.js.coffee
@@ -48,7 +48,7 @@ class Search
         when textStatus == 'timeout' then "The request timed out. Please try again."
         else
           # Rollbar.error("AJAX error: ", {xhr: xhr, textStatus: textStatus, errorThrown: errorThrown})
-          "An unknown error occurred. Try again, and if the problem continues, please email 4sweep@4sweep.com"
+          "An unknown error occurred. Try again, and if the problem continues, please email foursweep@foursquare.com"
 
     return {
       errorDetails: errorDetails

--- a/app/views/session/new.html.erb
+++ b/app/views/session/new.html.erb
@@ -32,13 +32,6 @@
       <li>Send your flags to Foursquare and track their approval</li>
     </ul>
   </div>
-  <div class="span3">
-    <p><strong>Popular Among Foursquare Superusers</strong></p>
-    <ul>
-      <p>Used by <%= number_with_delimiter(User.count, :delimiter => ',') %> superusers</p>
-      <p>Over <%= number_to_human(Flag.count, :delimiter => ",").downcase %> edits made</p>
-    </ul>
-  </div>
 
   </div>
   <hr>
@@ -49,7 +42,7 @@
     <hr>
     <p class='small'>4sweep is a Foursquare API tool that connects to your Foursquare account. 4sweep only uses your Foursquare account to submit flags to Foursquare, and collects only the minimum information needed to support that, such as your name and approximate last known location.
     </p><p class='small'>
-      This service uses the Foursquare® application programming interface but is not endorsed or certified by Foursquare Labs, Inc. All of the Foursquare® logos (including all badges) and trademarks displayed on this service are the property of Foursquare Labs, Inc.Some graphics from <a href="http://subtlepatterns.com/">Subtle Patterns</a> under CC BY-SA 3.0.</p>
+      All of the Foursquare® logos (including all badges) and trademarks displayed on this service are the property of Foursquare Labs, Inc.Some graphics from <a href="http://subtlepatterns.com/">Subtle Patterns</a> under CC BY-SA 3.0.</p>
 
   </div>
 </div>

--- a/app/views/session/new.html.erb
+++ b/app/views/session/new.html.erb
@@ -42,7 +42,7 @@
     <hr>
     <p class='small'>4sweep is a Foursquare API tool that connects to your Foursquare account. 4sweep only uses your Foursquare account to submit flags to Foursquare, and collects only the minimum information needed to support that, such as your name and approximate last known location.
     </p><p class='small'>
-      All of the Foursquare® logos (including all badges) and trademarks displayed on this service are the property of Foursquare Labs, Inc.Some graphics from <a href="http://subtlepatterns.com/">Subtle Patterns</a> under CC BY-SA 3.0.</p>
+      All of the Foursquare® logos (including all badges) and trademarks displayed on this service are the property of Foursquare Labs, Inc. Some graphics from <a href="http://subtlepatterns.com/">Subtle Patterns</a> under CC BY-SA 3.0.</p>
 
   </div>
 </div>

--- a/app/views/static_pages/contact.html.erb
+++ b/app/views/static_pages/contact.html.erb
@@ -9,27 +9,7 @@
 <div class="row-fluid">
   <div class="offset4 span4">
     <div class="alert alert-info">
-      Want to get in touch?  Here are the ways:
+      Want to get in touch?  Email us: <a href='mailto:foursweep@foursquare.com'>foursweep@foursquare.com</a>
     </div>
-
-    <table class="table table-striped offset4 span4">
-      <tr>
-        <th>Suggestions</th>
-        <td>Check out the <a href='https://www.google.com/moderator/#15/e=20d56e&amp;t=20d56e.45'>Google Moderator Forum</a> to make and vote on feature suggestions!</td>
-      </tr>
-      <tr>
-        <th>Email</th>
-        <td><a href='mailto:4sweep@4sweep.com'>4sweep@4sweep.com</a></td>
-      </tr>
-      <tr>
-        <th>Twitter</th>
-        <td><a href='https://twitter.com/4sweep'>@4sweep</a></td>
-      </tr>
-    <tfoot>
-      <tr>
-        <td colspan="2">&nbsp;</td>
-      </tr>
-    </tfoot>
-    </table>
   </div>
 </div>

--- a/app/views/static_pages/faq.html.erb
+++ b/app/views/static_pages/faq.html.erb
@@ -51,9 +51,6 @@
 
   <dt>What does "Alternate Resolution (Changed) mean?"</dt>
   <dd>You may see this status on Edit Venue flags. It means that 4sweep can't be certain that your flag was accepted exactly as you submitted it, probably because Foursquare normalized some field for you. For example, Foursquare automatically expands or shortens certain abbreviations, adds country codes to phone numbers, and performs many other automatic cleanups. When this happens, we resolve the flag as "Alternate Resolution (Changed)" if any of the fields you edited changed from their previous values. The vast majority of the time this means that your flag was accepted.</dd>
-
-  <dt>Any legal or other disclosures you need to make?</dt>
-  <dd>(Okay, nobody actually asks this one, but here is what Foursquare asks me to write):  <p>This service uses the Foursquare® application programming interface but is not endorsed or certified by Foursquare Labs, Inc. All of the Foursquare® logos (including all badges) and trademarks displayed on this service are the property of Foursquare Labs, Inc.</p></dd>
 </div>
 
 </dl>

--- a/public/500.html
+++ b/public/500.html
@@ -18,7 +18,7 @@
 
 <body>
   <div class="dialog">
-    <h1>We're sorry, but something went wrong.  If the problem persists, please tweet us at @4sweep or email 4sweep@4sweep.com for help.  Thanks!</h1>
+    <h1>We're sorry, but something went wrong.  If the problem persists, please tweet us at @4sweep or email foursweep@foursquare.com for help.  Thanks!</h1>
   </div>
 </body>
 </html>


### PR DESCRIPTION
- Update contact email address to foursweep@foursquare.com
- Remove references to 4sweep not being officially endorsed by Foursquare
- Remove references to defunct Google Moderator, Twitter account