### PR TITLE
images pushed should be in EAST not WEST region

### DIFF
--- a/build_local.sh
+++ b/build_local.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-IMAGE="087473112489.dkr.ecr.us-west-1.amazonaws.com/4sweep:latest"
+IMAGE="087473112489.dkr.ecr.us-east-1.amazonaws.com/4sweep:latest"
 
 if [ -f ~/.artifactory_creds ]; then
     ARTIFACTORY_CREDS=$(tr '\n' ' ' <<<$CREDS_FILE | sed "s/artifactory_username=\(.*\) artifactory_password=\(.*\)/\1:\2/")


### PR DESCRIPTION
> When pushing images to an ECR repo, only us-east-1 should be used. This is because this is the source registry and pushing an image here will trigger automatic replication into other regions.


https://foursquare.atlassian.net/wiki/spaces/PIG/pages/3161817181/ECR+Usage+-+Eng+Guide#Pushing-an-Image-Manually